### PR TITLE
Feature/encrypted database

### DIFF
--- a/pretixdroid/app/build.gradle
+++ b/pretixdroid/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "eu.pretix.pretixdroid"
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 12
-        versionName "1.10"
+        versionCode 13
+        versionName "1.20"
         vectorDrawables.useSupportLibrary = true
     }
 

--- a/pretixdroid/app/build.gradle
+++ b/pretixdroid/app/build.gradle
@@ -75,6 +75,8 @@ dependencies {
     compile 'joda-time:joda-time:2.9.9'
     compile 'io.requery:requery:1.4.1'
     compile 'io.requery:requery-android:1.4.1'
+    // Added encrypted database support
+    compile 'net.zetetic:android-database-sqlcipher:3.5.9'
     compile 'com.facebook.stetho:stetho:1.5.0'
     compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'

--- a/pretixdroid/app/build.gradle
+++ b/pretixdroid/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "eu.pretix.pretixdroid"
@@ -39,6 +39,7 @@ android {
 				sentry_dsn = "\"" + sentry_dsn + "\""
 			}
 		} catch (all) {
+            all
 			sentry_dsn = "null"
 		}
 
@@ -64,13 +65,13 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:27.0.0'
-    compile 'com.android.support:design:27.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:design:27.1.1'
     compile 'me.dm7.barcodescanner:zxing:1.9.3'
-    compile 'com.android.support:cardview-v7:27.0.0'
+    compile 'com.android.support:cardview-v7:27.1.1'
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
-    compile 'com.android.support:support-v4:27.0.0'
-    compile 'com.android.support:support-vector-drawable:27.0.0'
+    compile 'com.android.support:support-v4:27.1.1'
+    compile 'com.android.support:support-vector-drawable:27.1.1'
     compile 'com.joshdholtz.sentry:sentry-android:1.6.0'
     compile 'joda-time:joda-time:2.9.9'
     compile 'io.requery:requery:1.4.1'
@@ -79,7 +80,9 @@ dependencies {
     compile 'net.zetetic:android-database-sqlcipher:3.5.9'
     compile 'com.facebook.stetho:stetho:1.5.0'
     compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0'
+    // Added to support Silpion badge printing
+    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'
     annotationProcessor 'io.requery:requery-processor:1.4.1'
     compile(project(':libpretixsync')) {
         transitive = false

--- a/pretixdroid/app/build.gradle
+++ b/pretixdroid/app/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     compile 'net.zetetic:android-database-sqlcipher:3.5.9'
     compile 'com.facebook.stetho:stetho:1.5.0'
     compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
-    compile 'com.android.support.constraint:constraint-layout:1.1.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.2'
     // Added to support Silpion badge printing
     compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'
     annotationProcessor 'io.requery:requery-processor:1.4.1'

--- a/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/AppConfig.java
+++ b/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/AppConfig.java
@@ -45,7 +45,7 @@ public class AppConfig implements ConfigStore {
     public void setEventConfig(String url, String key, int version, boolean show_info, boolean allow_search) {
         prefs.edit()
                 .putString(PREFS_KEY_API_URL, url)
-                .putString(PREFS_KEY_API_KEY, key)
+                .putString(PREFS_KEY_API_KEY, KeystoreHelper.secureValue(key, true))
                 .putBoolean(PREFS_KEY_ALLOW_SEARCH, allow_search)
                 .putBoolean(PREFS_KEY_SHOW_INFO, show_info)
                 .putInt(PREFS_KEY_API_VERSION, version)
@@ -79,7 +79,8 @@ public class AppConfig implements ConfigStore {
     }
 
     public String getApiKey() {
-        return prefs.getString(PREFS_KEY_API_KEY, "");
+        String value = prefs.getString(PREFS_KEY_API_KEY, "");
+        return KeystoreHelper.secureValue(value, false);
     }
 
     public boolean getShowInfo() {

--- a/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/KeystoreHelper.java
+++ b/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/KeystoreHelper.java
@@ -56,8 +56,7 @@ public class KeystoreHelper {
                  *  It's quite ok to use ECB here, because:
                  *   - the "plaintext" will most likely fit into one or two encryption blocks
                  *   - the "plaintext" only contains pseudo-random printable characters
-                 *  Why we are doing this:
-                 *   - don't want to store an IV
+                 *   - we don't want to store an additional IV
                  */
                 @SuppressLint("GetInstance") Cipher cipher = Cipher.getInstance(
                         KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_ECB + "/"
@@ -68,8 +67,8 @@ public class KeystoreHelper {
                     byte[] bytes = cipher.doFinal(value.getBytes());
                     return Base64.encodeToString(bytes, Base64.NO_WRAP);
                 } else {
-                    byte[] bytes = Base64.decode(value, Base64.NO_WRAP);
                     cipher.init(Cipher.DECRYPT_MODE, key);
+                    byte[] bytes = Base64.decode(value, Base64.NO_WRAP);
                     return new String(cipher.doFinal(bytes), "UTF-8");
                 }
 

--- a/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/KeystoreHelper.java
+++ b/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/KeystoreHelper.java
@@ -1,5 +1,6 @@
 package eu.pretix.pretixdroid;
 
+import android.annotation.SuppressLint;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
@@ -51,7 +52,14 @@ public class KeystoreHelper {
                     key = (SecretKey) keyStore.getKey(SECURE_KEY_NAME, null);
                 }
 
-                Cipher cipher = Cipher.getInstance(
+                /*
+                 *  It's quite ok to use ECB here, because:
+                 *   - the "plaintext" will most likely fit into one or two encryption blocks
+                 *   - the "plaintext" only contains pseudo-random printable characters
+                 *  Why we are doing this:
+                 *   - don't want to store an IV
+                 */
+                @SuppressLint("GetInstance") Cipher cipher = Cipher.getInstance(
                         KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_ECB + "/"
                                 + KeyProperties.ENCRYPTION_PADDING_PKCS7);
 

--- a/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/KeystoreHelper.java
+++ b/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/KeystoreHelper.java
@@ -1,0 +1,83 @@
+package eu.pretix.pretixdroid;
+
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyPermanentlyInvalidatedException;
+import android.security.keystore.KeyProperties;
+import android.security.keystore.UserNotAuthenticatedException;
+import android.util.Base64;
+import android.util.Log;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+
+public class KeystoreHelper {
+
+    private static final String SECURE_KEY_NAME = "prefs_encryption_key";
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+
+    // Works since android M, for previous versions this will simply return the plain value unaltered
+    public static String secureValue(String value, boolean encrypt) {
+        if (value != null && value.length() > 0 && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            try {
+                KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+                keyStore.load(null);
+                SecretKey key = (SecretKey) keyStore.getKey(SECURE_KEY_NAME, null);
+
+                if(key == null) {
+                    KeyGenerator keyGenerator = KeyGenerator.getInstance(
+                            KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+                    keyGenerator.init(new KeyGenParameterSpec.Builder(SECURE_KEY_NAME,
+                            KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                            .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                            .setRandomizedEncryptionRequired(false)
+                            .build());
+                    keyGenerator.generateKey();
+                    key = (SecretKey) keyStore.getKey(SECURE_KEY_NAME, null);
+                }
+
+                Cipher cipher = Cipher.getInstance(
+                        KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_ECB + "/"
+                                + KeyProperties.ENCRYPTION_PADDING_PKCS7);
+
+                if (encrypt) {
+                    cipher.init(Cipher.ENCRYPT_MODE, key);
+                    byte[] bytes = cipher.doFinal(value.getBytes());
+                    return Base64.encodeToString(bytes, Base64.NO_WRAP);
+                } else {
+                    byte[] bytes = Base64.decode(value, Base64.NO_WRAP);
+                    cipher.init(Cipher.DECRYPT_MODE, key);
+                    return new String(cipher.doFinal(bytes), "UTF-8");
+                }
+
+            } catch (UserNotAuthenticatedException e) {
+                Log.d("KeystoreHelper","UserNotAuthenticatedException: " + e.getMessage());
+                return value;
+            } catch (KeyPermanentlyInvalidatedException e) {
+                Log.d("KeystoreHelper","KeyPermanentlyInvalidatedException: " + e.getMessage());
+                return value;
+            } catch (BadPaddingException | IllegalBlockSizeException | KeyStoreException |
+                    CertificateException | UnrecoverableKeyException | NoSuchPaddingException |
+                    NoSuchProviderException | IOException | InvalidAlgorithmParameterException |
+                    NoSuchAlgorithmException | InvalidKeyException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return value;
+    }
+}

--- a/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/PretixDroid.java
+++ b/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/PretixDroid.java
@@ -1,7 +1,6 @@
 package eu.pretix.pretixdroid;
 
 import android.app.Application;
-import android.database.sqlite.SQLiteDatabase;
 
 import com.facebook.stetho.Stetho;
 
@@ -46,7 +45,7 @@ public class PretixDroid extends Application {
 
             try {
                 // check if database has been decrypted
-                source.getReadableDatabase().execSQL("select count(*) from sqlite_master;");
+                source.getReadableDatabase().execSQL("select count(*) from sqlite_master;"); //source.getReadableDatabase().getSyncedTables() ???
             } catch(SQLiteException e) {
                 // if not, delete it
                 this.deleteDatabase(Models.DEFAULT.getName());

--- a/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/PretixDroid.java
+++ b/pretixdroid/app/src/main/java/eu/pretix/pretixdroid/PretixDroid.java
@@ -7,11 +7,10 @@ import com.facebook.stetho.Stetho;
 import eu.pretix.libpretixsync.check.AsyncCheckProvider;
 import eu.pretix.libpretixsync.check.OnlineCheckProvider;
 import eu.pretix.libpretixsync.check.TicketCheckProvider;
-import eu.pretix.libpretixsync.db.Migrations;
 import eu.pretix.libpretixsync.db.Models;
 import io.requery.BlockingEntityStore;
 import io.requery.Persistable;
-import io.requery.android.sqlite.DatabaseSource;
+import io.requery.android.sqlcipher.SqlCipherDatabaseSource;
 import io.requery.sql.Configuration;
 import io.requery.sql.EntityDataStore;
 
@@ -23,6 +22,7 @@ public class PretixDroid extends Application {
      * screwed either way.
      */
     public static final String KEYSTORE_PASSWORD = "ZnDNUkQ01PVZyD7oNP3a8DVXrvltxD";
+
     private BlockingEntityStore<Persistable> dataStore;
 
     @Override
@@ -37,9 +37,11 @@ public class PretixDroid extends Application {
     public BlockingEntityStore<Persistable> getData() {
         if (dataStore == null) {
             // override onUpgrade to handle migrating to a new version
-            DatabaseSource source = new DatabaseSource(this, Models.DEFAULT, 5);
+            SqlCipherDatabaseSource source = new SqlCipherDatabaseSource(this,
+                    Models.DEFAULT, Models.DEFAULT.getName(),
+                    KeystoreHelper.secureValue(KEYSTORE_PASSWORD, true), 5);
             Configuration configuration = source.getConfiguration();
-            dataStore = new EntityDataStore<Persistable>(configuration);
+            dataStore = new EntityDataStore<>(configuration);
         }
         return dataStore;
     }


### PR DESCRIPTION
This encrypts the database and the API-Key on the device using the AndroidKeyStore if it runs Android M or newer. On earlier versions, the database is still encrypted using a hard-coded value from the app for some obfuscation, the API-Key is kept in plain, though.
Caveat: Always deletes the on-device database if it cannot be decrypted